### PR TITLE
Add pre-migration tests for networking internals

### DIFF
--- a/changelog.d/627.misc
+++ b/changelog.d/627.misc
@@ -1,0 +1,1 @@
+Add test coverage for SRV resolution, .well-known routing, body size limiting, and replication TLS.

--- a/tests/test_blacklisting.py
+++ b/tests/test_blacklisting.py
@@ -9,15 +9,60 @@
 
 from unittest.mock import patch
 
+from netaddr import IPAddress, IPSet
 from twisted.internet.error import DNSLookupError
 from twisted.test.proto_helpers import StringTransport
 from twisted.trial.unittest import TestCase
 from twisted.web.client import Agent
 
-from sydent.http.blacklisting_reactor import BlacklistingReactorWrapper
+from sydent.http.blacklisting_reactor import (
+    BlacklistingReactorWrapper,
+    check_against_blacklist,
+)
 from sydent.http.srvresolver import Server
 
 from tests.utils import AsyncMock, make_request, make_sydent
+
+
+class CheckAgainstBlacklistTest(TestCase):
+    """Tests for the check_against_blacklist() utility function."""
+
+    def test_blacklisted_ipv4(self) -> None:
+        blacklist = IPSet(["5.0.0.0/8"])
+        self.assertTrue(check_against_blacklist(IPAddress("5.1.2.3"), None, blacklist))
+
+    def test_not_blacklisted(self) -> None:
+        blacklist = IPSet(["5.0.0.0/8"])
+        self.assertFalse(check_against_blacklist(IPAddress("1.2.3.4"), None, blacklist))
+
+    def test_whitelisted_overrides_blacklist(self) -> None:
+        blacklist = IPSet(["5.0.0.0/8"])
+        whitelist = IPSet(["5.1.1.1"])
+        self.assertFalse(
+            check_against_blacklist(IPAddress("5.1.1.1"), whitelist, blacklist)
+        )
+
+    def test_ipv6_loopback_blocked(self) -> None:
+        blacklist = IPSet(["::1/128"])
+        self.assertTrue(check_against_blacklist(IPAddress("::1"), None, blacklist))
+
+    def test_ipv6_link_local_blocked(self) -> None:
+        blacklist = IPSet(["fe80::/10"])
+        self.assertTrue(check_against_blacklist(IPAddress("fe80::1"), None, blacklist))
+
+    def test_ipv4_mapped_ipv6_blocked(self) -> None:
+        """IPv4-mapped IPv6 addresses (::ffff:127.0.0.1) should be blockable."""
+        blacklist = IPSet(["127.0.0.0/8", "::ffff:127.0.0.0/104"])
+        self.assertTrue(
+            check_against_blacklist(IPAddress("::ffff:127.0.0.1"), None, blacklist)
+        )
+
+    def test_ipv6_whitelist_overrides(self) -> None:
+        blacklist = IPSet(["fe80::/10"])
+        whitelist = IPSet(["fe80::1"])
+        self.assertFalse(
+            check_against_blacklist(IPAddress("fe80::1"), whitelist, blacklist)
+        )
 
 
 class BlacklistingAgentTest(TestCase):

--- a/tests/test_httpcommon.py
+++ b/tests/test_httpcommon.py
@@ -1,0 +1,181 @@
+# Copyright 2025 New Vector Ltd.
+#
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
+
+from io import BytesIO
+from unittest.mock import MagicMock
+
+from twisted.internet import defer
+from twisted.python.failure import Failure
+from twisted.trial import unittest
+from twisted.web.client import ResponseDone
+from twisted.web.http import PotentialDataLoss
+from twisted.web.iweb import UNKNOWN_LENGTH
+
+from sydent.http.httpcommon import (
+    BodyExceededMaxSize,
+    SizeLimitingRequest,
+    _DiscardBodyWithMaxSizeProtocol,
+    _ReadBodyWithMaxSizeProtocol,
+    read_body_with_max_size,
+)
+
+
+class ReadBodyWithMaxSizeProtocolTest(unittest.TestCase):
+    """Tests for _ReadBodyWithMaxSizeProtocol."""
+
+    def _make_protocol(
+        self, max_size: int | None = None
+    ) -> tuple[_ReadBodyWithMaxSizeProtocol, "defer.Deferred[bytes]"]:
+        d: defer.Deferred[bytes] = defer.Deferred()
+        protocol = _ReadBodyWithMaxSizeProtocol(d, max_size)
+        protocol.transport = MagicMock()
+        return protocol, d
+
+    def test_reads_body_under_limit(self) -> None:
+        """Body under the limit is read successfully."""
+        protocol, d = self._make_protocol(max_size=100)
+        protocol.dataReceived(b"hello ")
+        protocol.dataReceived(b"world")
+        protocol.connectionLost(Failure(ResponseDone()))
+        self.assertEqual(self.successResultOf(d), b"hello world")
+
+    def test_exceeds_max_size(self) -> None:
+        """Body exceeding max_size triggers BodyExceededMaxSize."""
+        protocol, d = self._make_protocol(max_size=5)
+        protocol.dataReceived(b"too much data")
+        self.failureResultOf(d, BodyExceededMaxSize)
+        protocol.transport.abortConnection.assert_called_once()
+
+    def test_exact_boundary(self) -> None:
+        """Body exactly at max_size triggers the error (>= check)."""
+        protocol, d = self._make_protocol(max_size=5)
+        protocol.dataReceived(b"12345")
+        self.failureResultOf(d, BodyExceededMaxSize)
+
+    def test_no_max_size(self) -> None:
+        """With max_size=None, any amount of data is accepted."""
+        protocol, d = self._make_protocol(max_size=None)
+        protocol.dataReceived(b"x" * 10000)
+        protocol.connectionLost(Failure(ResponseDone()))
+        self.assertEqual(len(self.successResultOf(d)), 10000)
+
+    def test_potential_data_loss_succeeds(self) -> None:
+        """PotentialDataLoss is treated as success (same as ResponseDone)."""
+        protocol, d = self._make_protocol(max_size=1000)
+        protocol.dataReceived(b"partial data")
+        protocol.connectionLost(Failure(PotentialDataLoss()))
+        self.assertEqual(self.successResultOf(d), b"partial data")
+
+    def test_connection_error_propagates(self) -> None:
+        """An unexpected connection loss reason propagates the error."""
+        protocol, d = self._make_protocol(max_size=1000)
+        protocol.dataReceived(b"some data")
+        error = Failure(Exception("connection reset"))
+        protocol.connectionLost(error)
+        f = self.failureResultOf(d)
+        self.assertIsInstance(f.value, Exception)
+
+
+class DiscardBodyWithMaxSizeProtocolTest(unittest.TestCase):
+    """Tests for _DiscardBodyWithMaxSizeProtocol."""
+
+    def test_errors_on_data_received(self) -> None:
+        """Fires errback and aborts connection on first data."""
+        d: defer.Deferred[bytes] = defer.Deferred()
+        protocol = _DiscardBodyWithMaxSizeProtocol(d)
+        protocol.transport = MagicMock()
+        protocol.dataReceived(b"any data")
+        self.failureResultOf(d, BodyExceededMaxSize)
+        protocol.transport.abortConnection.assert_called_once()
+
+    def test_errors_on_connection_lost(self) -> None:
+        """Also fires errback if connectionLost fires first."""
+        d: defer.Deferred[bytes] = defer.Deferred()
+        protocol = _DiscardBodyWithMaxSizeProtocol(d)
+        protocol.transport = MagicMock()
+        protocol.connectionLost(Failure(ResponseDone()))
+        self.failureResultOf(d, BodyExceededMaxSize)
+
+    def test_idempotent(self) -> None:
+        """Multiple calls to _maybe_fail don't double-fire the deferred."""
+        d: defer.Deferred[bytes] = defer.Deferred()
+        protocol = _DiscardBodyWithMaxSizeProtocol(d)
+        protocol.transport = MagicMock()
+        protocol.dataReceived(b"first")
+        protocol.dataReceived(b"second")  # should not raise
+        protocol.connectionLost(Failure(ResponseDone()))
+        self.failureResultOf(d, BodyExceededMaxSize)
+
+
+class ReadBodyWithMaxSizeFunctionTest(unittest.TestCase):
+    """Tests for the read_body_with_max_size() top-level function."""
+
+    def _make_response(self, length: int | object = UNKNOWN_LENGTH) -> MagicMock:
+        response = MagicMock()
+        response.length = length
+        return response
+
+    def test_content_length_exceeds_limit_uses_discard(self) -> None:
+        """When Content-Length > max_size, the Discard protocol is used."""
+        response = self._make_response(length=200)
+        read_body_with_max_size(response, max_size=100)
+        response.deliverBody.assert_called_once()
+        protocol = response.deliverBody.call_args[0][0]
+        self.assertIsInstance(protocol, _DiscardBodyWithMaxSizeProtocol)
+
+    def test_content_length_under_limit_uses_reader(self) -> None:
+        """When Content-Length <= max_size, the Read protocol is used."""
+        response = self._make_response(length=50)
+        read_body_with_max_size(response, max_size=100)
+        response.deliverBody.assert_called_once()
+        protocol = response.deliverBody.call_args[0][0]
+        self.assertIsInstance(protocol, _ReadBodyWithMaxSizeProtocol)
+
+    def test_unknown_length_uses_reader(self) -> None:
+        """When Content-Length is unknown, the Read protocol is used."""
+        response = self._make_response(length=UNKNOWN_LENGTH)
+        read_body_with_max_size(response, max_size=100)
+        response.deliverBody.assert_called_once()
+        protocol = response.deliverBody.call_args[0][0]
+        self.assertIsInstance(protocol, _ReadBodyWithMaxSizeProtocol)
+
+    def test_no_max_size_uses_reader(self) -> None:
+        """When max_size is None, always uses the Read protocol."""
+        response = self._make_response(length=999999)
+        read_body_with_max_size(response, max_size=None)
+        response.deliverBody.assert_called_once()
+        protocol = response.deliverBody.call_args[0][0]
+        self.assertIsInstance(protocol, _ReadBodyWithMaxSizeProtocol)
+
+
+class SizeLimitingRequestTest(unittest.TestCase):
+    """Tests for SizeLimitingRequest.handleContentChunk()."""
+
+    def _make_request(self) -> SizeLimitingRequest:
+        """Create a minimal SizeLimitingRequest for testing."""
+        req = SizeLimitingRequest.__new__(SizeLimitingRequest)
+        req.content = BytesIO()
+        req.transport = MagicMock()
+        # The client attribute is accessed for logging.
+        req.client = MagicMock()
+        return req
+
+    def test_accepts_data_under_limit(self) -> None:
+        """Chunks totalling under MAX_REQUEST_SIZE are accepted."""
+        req = self._make_request()
+        data = b"x" * 1000
+        req.handleContentChunk(data)
+        self.assertEqual(req.content.tell(), 1000)
+        req.transport.abortConnection.assert_not_called()
+
+    def test_aborts_on_oversize(self) -> None:
+        """Connection is aborted when cumulative data exceeds MAX_REQUEST_SIZE."""
+        req = self._make_request()
+        # Write data right up to the limit.
+        req.content.write(b"x" * (512 * 1024))
+        req.content.seek(512 * 1024)
+        # The next chunk pushes over.
+        req.handleContentChunk(b"x")
+        req.transport.abortConnection.assert_called_once()

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -1,6 +1,7 @@
 import json
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
+from OpenSSL import crypto
 from twisted.internet import defer
 from twisted.trial import unittest
 from twisted.web.client import Response
@@ -190,3 +191,101 @@ class ReplicationTestCase(unittest.TestCase):
             # will push will be 1, so we need to subtract 1 when figuring out which index
             # to lookup.
             self.assertDictEqual(assoc, signed_assocs[int(assoc_id) - 1])
+
+
+class ReplicationCNTest(unittest.TestCase):
+    """Tests for peer certificate CN extraction edge cases in the replication servlet."""
+
+    def setUp(self) -> None:
+        self.sydent = make_sydent()
+
+        # Insert a known peer.
+        cur = self.sydent.db.cursor()
+        cur.execute(
+            "INSERT INTO peers (name, port, lastSentVersion, active) VALUES (?, ?, ?, ?)",
+            ("fake.server", 1234, 0, 1),
+        )
+        peer_public_key_base64 = "+vB8mTaooD/MA8YYZM8t9+vnGhP1937q2icrqPV9JTs"
+        cur.execute(
+            "INSERT INTO peer_pubkeys (peername, alg, key) VALUES (?, ?, ?)",
+            ("fake.server", "ed25519", peer_public_key_base64),
+        )
+        self.sydent.db.commit()
+
+    def test_known_peer_cn_accepted(self) -> None:
+        """A peer cert with CN matching a known peer is accepted (existing test validates this,
+        but let's have a focused unit-level check)."""
+        self.sydent.run()
+
+        # The FakeChannel.getPeerCertificate() returns a cert with CN=fake.server,
+        # and we inserted fake.server as a peer. A valid request should be accepted.
+        body = {"sgAssocs": {}}
+        request, channel = make_request(
+            self.sydent.reactor,
+            self.sydent.replicationHttpsServer.factory,
+            "POST",
+            "/_matrix/identity/replicate/v1/push",
+            body,
+        )
+        self.assertEqual(channel.code, 200)
+
+    def test_unknown_peer_cn_rejected(self) -> None:
+        """A peer cert with CN that doesn't match any known peer returns 403."""
+        self.sydent.run()
+
+        # Generate a cert with a CN that is NOT in the peers table.
+        unknown_key = crypto.PKey()
+        unknown_key.generate_key(crypto.TYPE_RSA, 2048)
+        unknown_cert = crypto.X509()
+        unknown_cert.get_subject().CN = "unknown.server"
+        unknown_cert.set_serial_number(1000)
+        unknown_cert.gmtime_adj_notBefore(0)
+        unknown_cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
+        unknown_cert.set_issuer(unknown_cert.get_subject())
+        unknown_cert.set_pubkey(unknown_key)
+        unknown_cert.sign(unknown_key, "sha256")
+
+        # Patch FakeChannel.getPeerCertificate to return our unknown cert.
+        with patch(
+            "tests.utils.FakeChannel.getPeerCertificate", return_value=unknown_cert
+        ):
+            body = {"sgAssocs": {}}
+            request, channel = make_request(
+                self.sydent.reactor,
+                self.sydent.replicationHttpsServer.factory,
+                "POST",
+                "/_matrix/identity/replicate/v1/push",
+                body,
+            )
+        self.assertEqual(channel.code, 403)
+        self.assertEqual(channel.json_body["errcode"], "M_UNKNOWN_PEER")
+
+    def test_no_cn_rejected(self) -> None:
+        """A peer cert with no commonName returns 403."""
+        self.sydent.run()
+
+        # Generate a cert with no CN set.
+        no_cn_key = crypto.PKey()
+        no_cn_key.generate_key(crypto.TYPE_RSA, 2048)
+        no_cn_cert = crypto.X509()
+        # Don't set CN — leave subject empty.
+        no_cn_cert.set_serial_number(2000)
+        no_cn_cert.gmtime_adj_notBefore(0)
+        no_cn_cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
+        no_cn_cert.set_issuer(no_cn_cert.get_subject())
+        no_cn_cert.set_pubkey(no_cn_key)
+        no_cn_cert.sign(no_cn_key, "sha256")
+
+        with patch(
+            "tests.utils.FakeChannel.getPeerCertificate", return_value=no_cn_cert
+        ):
+            body = {"sgAssocs": {}}
+            request, channel = make_request(
+                self.sydent.reactor,
+                self.sydent.replicationHttpsServer.factory,
+                "POST",
+                "/_matrix/identity/replicate/v1/push",
+                body,
+            )
+        self.assertEqual(channel.code, 403)
+        self.assertEqual(channel.json_body["errcode"], "M_UNKNOWN_PEER")

--- a/tests/test_srvresolver.py
+++ b/tests/test_srvresolver.py
@@ -1,0 +1,218 @@
+# Copyright 2025 New Vector Ltd.
+#
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
+
+from unittest.mock import AsyncMock
+
+from twisted.internet.error import ConnectError
+from twisted.names import dns
+from twisted.names.error import DNSNameError, DomainError
+from twisted.trial import unittest
+
+from sydent.http.srvresolver import Server, SrvResolver, pick_server_from_list
+
+
+def _make_srv_answer(
+    host: bytes, port: int, priority: int = 0, weight: int = 0, ttl: int = 300
+) -> dns.RRHeader:
+    """Build an RRHeader wrapping a Record_SRV, as twisted.names would return."""
+    payload = dns.Record_SRV(
+        priority=priority,
+        weight=weight,
+        port=port,
+        target=host,
+    )
+    return dns.RRHeader(
+        type=dns.SRV,
+        payload=payload,
+        ttl=ttl,
+    )
+
+
+class PickServerFromListTest(unittest.TestCase):
+    """Tests for pick_server_from_list()."""
+
+    def test_single_server(self) -> None:
+        """When the list has one entry, that entry is always returned."""
+        s = Server(host=b"only.example.com", port=8448, priority=10, weight=1)
+        host, port = pick_server_from_list([s])
+        self.assertEqual(host, b"only.example.com")
+        self.assertEqual(port, 8448)
+
+    def test_empty_list_raises(self) -> None:
+        """An empty list should raise RuntimeError."""
+        self.assertRaises(RuntimeError, pick_server_from_list, [])
+
+    def test_priority_ordering(self) -> None:
+        """Only the lowest-priority servers should be selected."""
+        low = Server(host=b"low.example.com", port=1, priority=10, weight=1)
+        high = Server(host=b"high.example.com", port=2, priority=20, weight=1)
+        # Run many times — the high-priority server should never appear.
+        for _ in range(100):
+            host, port = pick_server_from_list([low, high])
+            self.assertEqual(host, b"low.example.com")
+
+    def test_weight_distribution(self) -> None:
+        """Within the same priority, servers are chosen proportionally to weight."""
+        heavy = Server(host=b"heavy.example.com", port=1, priority=10, weight=90)
+        light = Server(host=b"light.example.com", port=2, priority=10, weight=10)
+        counts: dict[bytes, int] = {b"heavy.example.com": 0, b"light.example.com": 0}
+        trials = 1000
+        for _ in range(trials):
+            host, _ = pick_server_from_list([heavy, light])
+            counts[host] += 1
+        # Heavy should get roughly 90% — allow wide margin for randomness.
+        self.assertGreater(counts[b"heavy.example.com"], trials * 0.7)
+        self.assertLess(counts[b"light.example.com"], trials * 0.3)
+
+    def test_zero_weight(self) -> None:
+        """A zero-weight server can still be chosen (RFC 2782 says small chance)."""
+        zero = Server(host=b"zero.example.com", port=1, priority=10, weight=0)
+        nonzero = Server(host=b"nonzero.example.com", port=2, priority=10, weight=100)
+        # With weight=0 vs 100, the zero server should very rarely be picked.
+        # Just verify it doesn't crash.
+        for _ in range(50):
+            pick_server_from_list([zero, nonzero])
+
+
+class SrvResolverTest(unittest.TestCase):
+    """Tests for SrvResolver.resolve_service()."""
+
+    def setUp(self) -> None:
+        self.mock_lookup = AsyncMock()
+        self.cache: dict[bytes, list[Server]] = {}
+        self.current_time = 1000
+        self.resolver = SrvResolver(
+            lookup_service=self.mock_lookup,
+            cache=self.cache,
+            get_time=lambda: self.current_time,
+        )
+
+    async def test_basic_lookup(self) -> None:
+        """A successful SRV lookup returns Server objects with correct fields."""
+        self.mock_lookup.return_value = (
+            [
+                _make_srv_answer(
+                    b"srv1.example.com", 8448, priority=10, weight=5, ttl=600
+                ),
+                _make_srv_answer(
+                    b"srv2.example.com", 8449, priority=20, weight=10, ttl=300
+                ),
+            ],
+            [],
+            [],
+        )
+
+        servers = await self.resolver.resolve_service(b"_matrix._tcp.example.com")
+
+        self.assertEqual(len(servers), 2)
+        self.assertEqual(servers[0].host, b"srv1.example.com")
+        self.assertEqual(servers[0].port, 8448)
+        self.assertEqual(servers[0].priority, 10)
+        self.assertEqual(servers[0].weight, 5)
+        self.assertEqual(servers[0].expires, 1600)  # 1000 + 600
+        self.assertEqual(servers[1].host, b"srv2.example.com")
+        self.assertEqual(servers[1].port, 8449)
+
+        self.mock_lookup.assert_awaited_once_with("_matrix._tcp.example.com")
+
+    async def test_results_are_cached(self) -> None:
+        """Subsequent calls within TTL return cached results without re-querying DNS."""
+        self.mock_lookup.return_value = (
+            [_make_srv_answer(b"cached.example.com", 8448, ttl=600)],
+            [],
+            [],
+        )
+
+        first = await self.resolver.resolve_service(b"_matrix._tcp.example.com")
+        self.assertEqual(len(first), 1)
+
+        # Advance time but stay within TTL.
+        self.current_time = 1500
+
+        second = await self.resolver.resolve_service(b"_matrix._tcp.example.com")
+        self.assertEqual(second, first)
+
+        # DNS should only have been queried once.
+        self.assertEqual(self.mock_lookup.await_count, 1)
+
+    async def test_cache_expires(self) -> None:
+        """After TTL expires, DNS is queried again."""
+        self.mock_lookup.return_value = (
+            [_make_srv_answer(b"old.example.com", 8448, ttl=600)],
+            [],
+            [],
+        )
+
+        await self.resolver.resolve_service(b"_matrix._tcp.example.com")
+
+        # Advance past TTL.
+        self.current_time = 1700
+
+        self.mock_lookup.return_value = (
+            [_make_srv_answer(b"new.example.com", 8448, ttl=600)],
+            [],
+            [],
+        )
+
+        servers = await self.resolver.resolve_service(b"_matrix._tcp.example.com")
+        self.assertEqual(servers[0].host, b"new.example.com")
+        self.assertEqual(self.mock_lookup.await_count, 2)
+
+    async def test_dns_name_error_returns_empty(self) -> None:
+        """DNSNameError (name doesn't exist) returns an empty list."""
+        self.mock_lookup.side_effect = DNSNameError()
+
+        servers = await self.resolver.resolve_service(b"_matrix._tcp.nonexistent.com")
+        self.assertEqual(servers, [])
+
+    async def test_domain_error_falls_back_to_cache(self) -> None:
+        """On transient DNS failure, stale cached entries are returned."""
+        # First call succeeds and populates cache.
+        self.mock_lookup.return_value = (
+            [_make_srv_answer(b"cached.example.com", 8448, ttl=60)],
+            [],
+            [],
+        )
+        await self.resolver.resolve_service(b"_matrix._tcp.example.com")
+
+        # Advance past TTL.
+        self.current_time = 1200
+
+        # Second call fails with transient error.
+        self.mock_lookup.side_effect = DomainError()
+
+        servers = await self.resolver.resolve_service(b"_matrix._tcp.example.com")
+        self.assertEqual(len(servers), 1)
+        self.assertEqual(servers[0].host, b"cached.example.com")
+
+    async def test_domain_error_no_cache_raises(self) -> None:
+        """DomainError with no cache entry re-raises."""
+        self.mock_lookup.side_effect = DomainError()
+
+        with self.assertRaises(DomainError):
+            await self.resolver.resolve_service(b"_matrix._tcp.nocache.com")
+
+    async def test_service_unavailable_target_dot(self) -> None:
+        """A single SRV record pointing to '.' means the service is unavailable."""
+        self.mock_lookup.return_value = (
+            [_make_srv_answer(b".", 0, ttl=600)],
+            [],
+            [],
+        )
+
+        with self.assertRaises(ConnectError):
+            await self.resolver.resolve_service(b"_matrix._tcp.example.com")
+
+    async def test_non_srv_records_filtered(self) -> None:
+        """Non-SRV answer records are ignored."""
+        srv = _make_srv_answer(b"real.example.com", 8448, ttl=300)
+        # Create a non-SRV record (e.g., A record type).
+        non_srv = dns.RRHeader(type=dns.A, payload=None, ttl=300)
+
+        self.mock_lookup.return_value = ([srv, non_srv], [], [])
+
+        servers = await self.resolver.resolve_service(b"_matrix._tcp.example.com")
+        self.assertEqual(len(servers), 1)
+        self.assertEqual(servers[0].host, b"real.example.com")

--- a/tests/test_wellknown.py
+++ b/tests/test_wellknown.py
@@ -1,0 +1,451 @@
+# Copyright 2025 New Vector Ltd.
+#
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
+
+"""Tests for MatrixFederationAgent server discovery (.well-known, SRV, routing)."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from twisted.internet import defer
+from twisted.trial import unittest
+from twisted.web.client import URI
+from twisted.web.http_headers import Headers
+
+from sydent.http.matrixfederationagent import (
+    WELL_KNOWN_INVALID_CACHE_PERIOD,
+    WELL_KNOWN_MAX_CACHE_PERIOD,
+    MatrixFederationAgent,
+    _cache_period_from_headers,
+    _parse_cache_control,
+)
+from sydent.http.srvresolver import Server, SrvResolver
+from sydent.util.ttlcache import TTLCache
+
+from tests.utils import ResolvingMemoryReactorClock
+
+
+def _make_well_known_response(
+    body: bytes | None = None,
+    status: int = 200,
+    headers: dict[bytes, list[bytes]] | None = None,
+) -> MagicMock:
+    """Build a fake IResponse for .well-known fetches."""
+    response = MagicMock()
+    response.code = status
+    response.headers = Headers()
+    if headers:
+        for k, vs in headers.items():
+            for v in vs:
+                response.headers.addRawHeader(k, v)
+    return response
+
+
+class ParseCacheControlTest(unittest.TestCase):
+    """Tests for _parse_cache_control()."""
+
+    def test_max_age(self) -> None:
+        headers = Headers()
+        headers.addRawHeader(b"cache-control", b"max-age=3600")
+        result = _parse_cache_control(headers)
+        self.assertEqual(result[b"max-age"], b"3600")
+
+    def test_multiple_directives(self) -> None:
+        headers = Headers()
+        headers.addRawHeader(b"cache-control", b"no-store, max-age=300")
+        result = _parse_cache_control(headers)
+        self.assertIn(b"no-store", result)
+        self.assertEqual(result[b"max-age"], b"300")
+
+    def test_no_value_directive(self) -> None:
+        headers = Headers()
+        headers.addRawHeader(b"cache-control", b"no-cache")
+        result = _parse_cache_control(headers)
+        self.assertIn(b"no-cache", result)
+        self.assertIsNone(result[b"no-cache"])
+
+    def test_empty_headers(self) -> None:
+        headers = Headers()
+        result = _parse_cache_control(headers)
+        self.assertEqual(result, {})
+
+
+class CachePeriodFromHeadersTest(unittest.TestCase):
+    """Tests for _cache_period_from_headers()."""
+
+    def test_max_age(self) -> None:
+        headers = Headers()
+        headers.addRawHeader(b"cache-control", b"max-age=7200")
+        period = _cache_period_from_headers(headers)
+        self.assertEqual(period, 7200)
+
+    def test_no_store(self) -> None:
+        headers = Headers()
+        headers.addRawHeader(b"cache-control", b"no-store")
+        period = _cache_period_from_headers(headers)
+        self.assertEqual(period, 0)
+
+    def test_expires_header(self) -> None:
+        headers = Headers()
+        # Use an Expires header in HTTP date format.
+        headers.addRawHeader(b"expires", b"Thu, 01 Jan 2099 00:00:00 GMT")
+        period = _cache_period_from_headers(headers, time_now=lambda: 0)
+        self.assertIsNotNone(period)
+        assert period is not None
+        self.assertGreater(period, 0)
+
+    def test_invalid_expires(self) -> None:
+        """Invalid Expires values should return 0 (already expired)."""
+        headers = Headers()
+        headers.addRawHeader(b"expires", b"0")
+        period = _cache_period_from_headers(headers, time_now=lambda: 1000)
+        self.assertEqual(period, 0)
+
+    def test_no_cache_headers(self) -> None:
+        headers = Headers()
+        period = _cache_period_from_headers(headers)
+        self.assertIsNone(period)
+
+    def test_max_age_takes_precedence_over_expires(self) -> None:
+        headers = Headers()
+        headers.addRawHeader(b"cache-control", b"max-age=100")
+        headers.addRawHeader(b"expires", b"Thu, 01 Jan 2099 00:00:00 GMT")
+        period = _cache_period_from_headers(headers)
+        self.assertEqual(period, 100)
+
+
+class RouteMatrixUriTest(unittest.TestCase):
+    """Tests for MatrixFederationAgent._route_matrix_uri() discovery chain."""
+
+    def setUp(self) -> None:
+        self.reactor = ResolvingMemoryReactorClock()
+        self.mock_srv_resolver = MagicMock(spec=SrvResolver)
+        self.mock_srv_resolver.resolve_service = AsyncMock(return_value=[])
+        self.well_known_cache: TTLCache[bytes, bytes | None] = TTLCache("test-wk")
+
+        self.agent = MatrixFederationAgent(
+            reactor=self.reactor,
+            tls_client_options_factory=None,
+            _srv_resolver=self.mock_srv_resolver,
+            _well_known_cache=self.well_known_cache,
+        )
+
+    async def test_ip_literal_default_port(self) -> None:
+        """An IP literal with no port defaults to 8448."""
+        uri = URI.fromBytes(b"matrix-federation://1.2.3.4/some/path", defaultPort=-1)
+        result = await self.agent._route_matrix_uri(uri)
+        self.assertEqual(result.target_host, b"1.2.3.4")
+        self.assertEqual(result.target_port, 8448)
+        self.assertEqual(result.tls_server_name, b"1.2.3.4")
+
+    async def test_ip_literal_explicit_port(self) -> None:
+        """An IP literal with an explicit port uses that port."""
+        uri = URI.fromBytes(b"matrix-federation://1.2.3.4:9999/path", defaultPort=-1)
+        result = await self.agent._route_matrix_uri(uri)
+        self.assertEqual(result.target_host, b"1.2.3.4")
+        self.assertEqual(result.target_port, 9999)
+
+    async def test_explicit_port_skips_well_known_and_srv(self) -> None:
+        """A hostname with an explicit port skips .well-known and SRV lookups."""
+        uri = URI.fromBytes(
+            b"matrix-federation://example.com:8449/path", defaultPort=-1
+        )
+        result = await self.agent._route_matrix_uri(uri)
+        self.assertEqual(result.target_host, b"example.com")
+        self.assertEqual(result.target_port, 8449)
+        self.assertEqual(result.host_header, b"example.com:8449")
+        # No SRV lookups should have occurred.
+        self.mock_srv_resolver.resolve_service.assert_not_awaited()
+
+    async def test_well_known_delegates(self) -> None:
+        """A valid .well-known response redirects to the delegated server."""
+        # Pre-populate the .well-known cache to avoid needing to mock HTTP.
+        self.well_known_cache.set(b"example.com", b"delegated.example.com:8448", 3600)
+
+        uri = URI.fromBytes(b"matrix-federation://example.com/path", defaultPort=-1)
+        result = await self.agent._route_matrix_uri(uri)
+        self.assertEqual(result.target_host, b"delegated.example.com")
+        self.assertEqual(result.target_port, 8448)
+        self.assertEqual(result.host_header, b"delegated.example.com:8448")
+        self.assertEqual(result.tls_server_name, b"delegated.example.com")
+
+    async def test_well_known_delegates_no_port_falls_to_srv(self) -> None:
+        """A .well-known with no port triggers SRV lookup on delegated host."""
+        self.well_known_cache.set(b"example.com", b"delegated.example.com", 3600)
+
+        self.mock_srv_resolver.resolve_service.return_value = [
+            Server(
+                host=b"srv.delegated.example.com",
+                port=443,
+                priority=1,
+                weight=1,
+                expires=9999,
+            )
+        ]
+
+        uri = URI.fromBytes(b"matrix-federation://example.com/path", defaultPort=-1)
+        result = await self.agent._route_matrix_uri(uri)
+        self.assertEqual(result.target_host, b"srv.delegated.example.com")
+        self.assertEqual(result.target_port, 443)
+
+    async def test_well_known_none_falls_to_srv(self) -> None:
+        """When .well-known returns None, fall through to SRV."""
+        self.well_known_cache.set(b"example.com", None, 3600)
+
+        self.mock_srv_resolver.resolve_service.return_value = [
+            Server(
+                host=b"srv.example.com", port=8448, priority=1, weight=1, expires=9999
+            )
+        ]
+
+        uri = URI.fromBytes(b"matrix-federation://example.com/path", defaultPort=-1)
+        result = await self.agent._route_matrix_uri(uri)
+        self.assertEqual(result.target_host, b"srv.example.com")
+        self.assertEqual(result.target_port, 8448)
+
+    async def test_matrix_fed_srv_preferred_over_matrix_srv(self) -> None:
+        """_matrix-fed._tcp SRV is tried first (Matrix 1.8)."""
+        call_count = 0
+
+        async def mock_resolve(service_name: bytes) -> list[Server]:
+            nonlocal call_count
+            call_count += 1
+            if service_name == b"_matrix-fed._tcp.example.com":
+                return [
+                    Server(
+                        host=b"fed.example.com",
+                        port=443,
+                        priority=1,
+                        weight=1,
+                        expires=9999,
+                    )
+                ]
+            return []
+
+        self.mock_srv_resolver.resolve_service = mock_resolve  # type: ignore[assignment]
+
+        # Ensure no .well-known
+        self.well_known_cache.set(b"example.com", None, 3600)
+
+        uri = URI.fromBytes(b"matrix-federation://example.com/path", defaultPort=-1)
+        result = await self.agent._route_matrix_uri(uri)
+        self.assertEqual(result.target_host, b"fed.example.com")
+        self.assertEqual(result.target_port, 443)
+        # Should have only queried _matrix-fed (not _matrix) since it returned results.
+        self.assertEqual(call_count, 1)
+
+    async def test_fallback_to_legacy_matrix_srv(self) -> None:
+        """When _matrix-fed._tcp returns nothing, _matrix._tcp is tried."""
+        call_count = 0
+
+        async def mock_resolve(service_name: bytes) -> list[Server]:
+            nonlocal call_count
+            call_count += 1
+            if service_name == b"_matrix._tcp.example.com":
+                return [
+                    Server(
+                        host=b"legacy.example.com",
+                        port=8448,
+                        priority=1,
+                        weight=1,
+                        expires=9999,
+                    )
+                ]
+            return []
+
+        self.mock_srv_resolver.resolve_service = mock_resolve  # type: ignore[assignment]
+        self.well_known_cache.set(b"example.com", None, 3600)
+
+        uri = URI.fromBytes(b"matrix-federation://example.com/path", defaultPort=-1)
+        result = await self.agent._route_matrix_uri(uri)
+        self.assertEqual(result.target_host, b"legacy.example.com")
+        self.assertEqual(result.target_port, 8448)
+        # Both SRV lookups should have been attempted.
+        self.assertEqual(call_count, 2)
+
+    async def test_no_srv_defaults_to_8448(self) -> None:
+        """When no SRV records exist, default to port 8448 on the original host."""
+        self.mock_srv_resolver.resolve_service.return_value = []
+        self.well_known_cache.set(b"example.com", None, 3600)
+
+        uri = URI.fromBytes(b"matrix-federation://example.com/path", defaultPort=-1)
+        result = await self.agent._route_matrix_uri(uri)
+        self.assertEqual(result.target_host, b"example.com")
+        self.assertEqual(result.target_port, 8448)
+
+
+class DoGetWellKnownTest(unittest.TestCase):
+    """Tests for MatrixFederationAgent._do_get_well_known()."""
+
+    def setUp(self) -> None:
+        self.reactor = ResolvingMemoryReactorClock()
+        self.reactor.seconds = lambda: 1000.0  # type: ignore[assignment]
+        self.mock_srv_resolver = MagicMock(spec=SrvResolver)
+        self.well_known_cache: TTLCache[bytes, bytes | None] = TTLCache("test-wk")
+
+        self.agent = MatrixFederationAgent(
+            reactor=self.reactor,
+            tls_client_options_factory=None,
+            _srv_resolver=self.mock_srv_resolver,
+            _well_known_cache=self.well_known_cache,
+        )
+
+    @patch("sydent.http.matrixfederationagent.read_body_with_max_size")
+    async def test_valid_well_known(self, mock_read_body: MagicMock) -> None:
+        """A valid .well-known response returns the delegated server."""
+        body = json.dumps({"m.server": "delegated.example.com:8448"}).encode()
+        mock_read_body.return_value = defer.succeed(body)
+
+        response = _make_well_known_response(status=200)
+        self.agent._well_known_agent = MagicMock()
+        self.agent._well_known_agent.request = AsyncMock(return_value=response)
+
+        result, cache_period = await self.agent._do_get_well_known(b"example.com")
+        self.assertEqual(result, b"delegated.example.com:8448")
+        self.assertGreater(cache_period, 0)
+
+    @patch("sydent.http.matrixfederationagent.read_body_with_max_size")
+    async def test_non_200_returns_none(self, mock_read_body: MagicMock) -> None:
+        """A non-200 response results in None (no delegation)."""
+        mock_read_body.return_value = defer.succeed(b"Not Found")
+        response = _make_well_known_response(status=404)
+        self.agent._well_known_agent = MagicMock()
+        self.agent._well_known_agent.request = AsyncMock(return_value=response)
+
+        result, cache_period = await self.agent._do_get_well_known(b"example.com")
+        self.assertIsNone(result)
+        # Should cache the failure.
+        self.assertGreaterEqual(cache_period, WELL_KNOWN_INVALID_CACHE_PERIOD)
+
+    @patch("sydent.http.matrixfederationagent.read_body_with_max_size")
+    async def test_invalid_json_returns_none(self, mock_read_body: MagicMock) -> None:
+        """Invalid JSON in .well-known returns None."""
+        mock_read_body.return_value = defer.succeed(b"not json at all")
+        response = _make_well_known_response(status=200)
+        self.agent._well_known_agent = MagicMock()
+        self.agent._well_known_agent.request = AsyncMock(return_value=response)
+
+        result, _ = await self.agent._do_get_well_known(b"example.com")
+        self.assertIsNone(result)
+
+    @patch("sydent.http.matrixfederationagent.read_body_with_max_size")
+    async def test_missing_m_server_key(self, mock_read_body: MagicMock) -> None:
+        """JSON without m.server key returns None."""
+        mock_read_body.return_value = defer.succeed(
+            json.dumps({"other": "key"}).encode()
+        )
+        response = _make_well_known_response(status=200)
+        self.agent._well_known_agent = MagicMock()
+        self.agent._well_known_agent.request = AsyncMock(return_value=response)
+
+        result, _ = await self.agent._do_get_well_known(b"example.com")
+        self.assertIsNone(result)
+
+    @patch("sydent.http.matrixfederationagent.read_body_with_max_size")
+    async def test_m_server_not_string(self, mock_read_body: MagicMock) -> None:
+        """m.server with non-string value returns None."""
+        mock_read_body.return_value = defer.succeed(
+            json.dumps({"m.server": 12345}).encode()
+        )
+        response = _make_well_known_response(status=200)
+        self.agent._well_known_agent = MagicMock()
+        self.agent._well_known_agent.request = AsyncMock(return_value=response)
+
+        result, _ = await self.agent._do_get_well_known(b"example.com")
+        self.assertIsNone(result)
+
+    @patch("sydent.http.matrixfederationagent.read_body_with_max_size")
+    async def test_cache_control_max_age(self, mock_read_body: MagicMock) -> None:
+        """Cache-Control max-age is respected, capped at WELL_KNOWN_MAX_CACHE_PERIOD."""
+        body = json.dumps({"m.server": "delegated.example.com:8448"}).encode()
+        mock_read_body.return_value = defer.succeed(body)
+        response = _make_well_known_response(
+            status=200,
+            headers={b"cache-control": [b"max-age=7200"]},
+        )
+        self.agent._well_known_agent = MagicMock()
+        self.agent._well_known_agent.request = AsyncMock(return_value=response)
+
+        _, cache_period = await self.agent._do_get_well_known(b"example.com")
+        self.assertEqual(cache_period, 7200)
+
+    @patch("sydent.http.matrixfederationagent.read_body_with_max_size")
+    async def test_cache_period_capped(self, mock_read_body: MagicMock) -> None:
+        """Cache period is capped at WELL_KNOWN_MAX_CACHE_PERIOD (48h)."""
+        body = json.dumps({"m.server": "delegated.example.com:8448"}).encode()
+        mock_read_body.return_value = defer.succeed(body)
+        # Request a cache period of 1 week.
+        response = _make_well_known_response(
+            status=200,
+            headers={b"cache-control": [b"max-age=604800"]},
+        )
+        self.agent._well_known_agent = MagicMock()
+        self.agent._well_known_agent.request = AsyncMock(return_value=response)
+
+        _, cache_period = await self.agent._do_get_well_known(b"example.com")
+        self.assertEqual(cache_period, WELL_KNOWN_MAX_CACHE_PERIOD)
+
+    @patch("sydent.http.matrixfederationagent.read_body_with_max_size")
+    async def test_request_exception_returns_none(
+        self, mock_read_body: MagicMock
+    ) -> None:
+        """If the HTTP request itself throws, return None."""
+        self.agent._well_known_agent = MagicMock()
+        self.agent._well_known_agent.request = AsyncMock(
+            side_effect=Exception("connection refused")
+        )
+
+        result, cache_period = await self.agent._do_get_well_known(b"example.com")
+        self.assertIsNone(result)
+        self.assertGreaterEqual(cache_period, WELL_KNOWN_INVALID_CACHE_PERIOD)
+
+
+class GetWellKnownCachingTest(unittest.TestCase):
+    """Tests for MatrixFederationAgent._get_well_known() caching behaviour."""
+
+    def setUp(self) -> None:
+        self.reactor = ResolvingMemoryReactorClock()
+        self.reactor.seconds = lambda: 1000.0  # type: ignore[assignment]
+        self.mock_srv_resolver = MagicMock(spec=SrvResolver)
+        self.well_known_cache: TTLCache[bytes, bytes | None] = TTLCache("test-wk")
+
+        self.agent = MatrixFederationAgent(
+            reactor=self.reactor,
+            tls_client_options_factory=None,
+            _srv_resolver=self.mock_srv_resolver,
+            _well_known_cache=self.well_known_cache,
+        )
+
+    async def test_cached_result_returned(self) -> None:
+        """A cached .well-known result is returned without re-fetching."""
+        self.well_known_cache.set(b"example.com", b"cached.example.com:8448", 3600)
+
+        result = await self.agent._get_well_known(b"example.com")
+        self.assertEqual(result, b"cached.example.com:8448")
+
+    async def test_cached_none_returned(self) -> None:
+        """A cached None (failed lookup) is returned."""
+        self.well_known_cache.set(b"example.com", None, 3600)
+
+        result = await self.agent._get_well_known(b"example.com")
+        self.assertIsNone(result)
+
+    @patch("sydent.http.matrixfederationagent.read_body_with_max_size")
+    async def test_cache_miss_fetches(self, mock_read_body: MagicMock) -> None:
+        """A cache miss triggers a fetch and caches the result."""
+        body = json.dumps({"m.server": "new.example.com:8448"}).encode()
+        mock_read_body.return_value = defer.succeed(body)
+        response = _make_well_known_response(
+            status=200,
+            headers={b"cache-control": [b"max-age=3600"]},
+        )
+        self.agent._well_known_agent = MagicMock()
+        self.agent._well_known_agent.request = AsyncMock(return_value=response)
+
+        result = await self.agent._get_well_known(b"fresh.example.com")
+        self.assertEqual(result, b"new.example.com:8448")
+
+        # The result should now be in cache.
+        cached = self.well_known_cache.get(b"fresh.example.com")
+        self.assertEqual(cached, b"new.example.com:8448")


### PR DESCRIPTION
## Summary

Add test coverage for networking subsystems before the Twisted → aiohttp migration:

- **test_httpcommon.py**: HTTP body size limiting (`_ReadBodyWithMaxSizeProtocol`, `_DiscardBodyWithMaxSizeProtocol`, `SizeLimitingRequest`)
- **test_srvresolver.py**: SRV record resolution (`pick_server_from_list`, `SrvResolver.resolve_service`, caching, DNS errors)
- **test_wellknown.py**: Matrix federation discovery chain (`.well-known` routing, cache control parsing, `_route_matrix_uri`)
- **test_blacklisting.py**: IP blacklist/whitelist checking (IPv4, IPv6, link-local, loopback)
- **test_replication.py**: Peer certificate CN validation (known/unknown/missing CN)

## Test plan

- [x] `uv run trial tests/` — 117 tests pass (+68 new)
- [x] CI green

> Part 7 of 9 in the modernisation series. Builds on #626.