### PR TITLE
Fix the docker directory in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,7 +39,7 @@ updates:
       default-days: 14
 
   - package-ecosystem: "docker"
-    directory: "/docker"
+    directory: "/"
     open-pull-requests-limit: 10
     schedule:
       interval: "weekly"

--- a/changelog.d/629.misc
+++ b/changelog.d/629.misc
@@ -1,0 +1,1 @@
+Add a GitHub dependabot config to the repository to keep our dependencies up to date.


### PR DESCRIPTION
Copy/paste error from other dependabot configs. There is no `/docker` directory in this repo. Instead, there's a top-level Dockerfile.

### Pull Request Checklist

* [x] Pull request includes a [changelog file](https://github.com/element-hq/sydent/blob/main/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fix a bug that prevented receiving messages from other servers." instead of "Move X method from `EventStore` to `EventWorkerStore`.".
  - Include 'Contributed by *Your Name*.' or 'Contributed by @*your-github-username*.' — unless you would prefer not to be credited in the changelog.
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] Pull request includes a [sign off](https://github.com/element-hq/synapse/blob/master/CONTRIBUTING.md#sign-off)
