### PR TITLE
Replace `--no-dev` with `--without dev` in poetry commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY --chown=sydent:sydent ["sydent", "sydent"]
 COPY --chown=sydent:sydent ["README.rst", "pyproject.toml", "poetry.lock", "./"]
 
 # Install dependencies
-RUN python -m poetry install -vv --no-dev --no-interaction --extras "prometheus sentry"
+RUN python -m poetry install -vv --without dev --no-interaction --extras "prometheus sentry"
 
 # Record dependencies for posterity
 RUN python -m poetry export -o requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ First install `poetry`. See `poetry's documentation <https://python-poetry.org/d
 
     git clone https://github.com/element-hq/sydent.git
     cd sydent
-    poetry install --no-dev
+    poetry install --without dev
     # For development, pull in extra tools with
     # poetry install
 

--- a/changelog.d/637.misc
+++ b/changelog.d/637.misc
@@ -1,0 +1,1 @@
+Replace old `--no-dev` poetry argument with `--without dev` in documentation and Dockerfile.


### PR DESCRIPTION
Fixes https://github.com/element-hq/sydent/issues/631

The `--no-dev` argument was removed back in 2025. See https://github.com/orgs/python-poetry/discussions/10096.

`--without dev` still works with poetry 1, as demonstrated by the dockerfile, which built locally for me.

### Pull Request Checklist

* [x] Pull request includes a [changelog file](https://github.com/element-hq/sydent/blob/main/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fix a bug that prevented receiving messages from other servers." instead of "Move X method from `EventStore` to `EventWorkerStore`.".
  - Include 'Contributed by *Your Name*.' or 'Contributed by @*your-github-username*.' — unless you would prefer not to be credited in the changelog.
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] Pull request includes a [sign off](https://github.com/element-hq/synapse/blob/master/CONTRIBUTING.md#sign-off)
